### PR TITLE
feat: Use XCFramework for Apple binaries

### DIFF
--- a/amount/build.gradle.kts
+++ b/amount/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
@@ -16,6 +18,8 @@ kotlin {
         }
     }
     jvm()
+
+    val xcf = XCFramework()
     listOf(
         iosX64(),
         iosArm64(),
@@ -25,6 +29,7 @@ kotlin {
     ).forEach {
         it.binaries.framework {
             baseName = "Amount"
+            xcf.add(this)
         }
     }
 

--- a/base58/build.gradle.kts
+++ b/base58/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
@@ -16,6 +18,8 @@ kotlin {
         }
     }
     jvm()
+
+    val xcf = XCFramework()
     listOf(
         iosX64(),
         iosArm64(),
@@ -25,6 +29,7 @@ kotlin {
     ).forEach {
         it.binaries.framework {
             baseName = "Base58"
+            xcf.add(this)
         }
     }
 

--- a/readapi/build.gradle.kts
+++ b/readapi/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
@@ -18,6 +20,8 @@ kotlin {
     }
 
     jvm()
+
+    val xcf = XCFramework()
     listOf(
         iosX64(),
         iosArm64(),
@@ -27,6 +31,7 @@ kotlin {
     ).forEach {
         it.binaries.framework {
             baseName = "MetaplexReadApi"
+            xcf.add(this)
         }
     }
 

--- a/solana/build.gradle.kts
+++ b/solana/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
@@ -16,6 +18,8 @@ kotlin {
         }
     }
     jvm()
+
+    val xcf = XCFramework()
     listOf(
         iosX64(),
         iosArm64(),
@@ -25,6 +29,7 @@ kotlin {
     ).forEach {
         it.binaries.framework {
             baseName = "Solana"
+            xcf.add(this)
         }
     }
 

--- a/solanaeddsa/build.gradle.kts
+++ b/solanaeddsa/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
@@ -18,6 +20,8 @@ kotlin {
         }
     }
     jvm()
+
+    val xcf = XCFramework()
     listOf(
         iosX64(),
         iosArm64(),
@@ -27,6 +31,7 @@ kotlin {
     ).forEach {
         it.binaries.framework {
             baseName = "SolanaEddsa"
+            xcf.add(this)
         }
     }
 

--- a/solanainterfaces/build.gradle.kts
+++ b/solanainterfaces/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
@@ -16,6 +18,8 @@ kotlin {
         }
     }
     jvm()
+
+    val xcf = XCFramework()
     listOf(
         iosX64(),
         iosArm64(),
@@ -25,6 +29,7 @@ kotlin {
     ).forEach {
         it.binaries.framework {
             baseName = "SolanaInterfaces"
+            xcf.add(this)
         }
     }
 

--- a/solanakeypair/build.gradle.kts
+++ b/solanakeypair/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
@@ -16,6 +18,8 @@ kotlin {
         }
     }
     jvm()
+
+    val xcf = XCFramework()
     listOf(
         iosX64(),
         iosArm64(),
@@ -25,6 +29,7 @@ kotlin {
     ).forEach {
         it.binaries.framework {
             baseName = "SolanaKeypair"
+            xcf.add(this)
         }
     }
 

--- a/solanapublickeys/build.gradle.kts
+++ b/solanapublickeys/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
@@ -16,6 +18,8 @@ kotlin {
         }
     }
     jvm()
+
+    val xcf = XCFramework()
     listOf(
         iosX64(),
         iosArm64(),
@@ -25,6 +29,7 @@ kotlin {
     ).forEach {
         it.binaries.framework {
             baseName = "SolanaPublicKeys"
+            xcf.add(this)
         }
     }
 


### PR DESCRIPTION
- Import the `org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework` library
- Add XCFramework binaries for various iOS and macOS platforms