### PR TITLE
fix: Update NetworkingTests to use correct URL and assert non-null re…

### DIFF
--- a/rpc/src/commonTest/kotlin/foundation/metaplex/rpc/networking/NetworkingTests.kt
+++ b/rpc/src/commonTest/kotlin/foundation/metaplex/rpc/networking/NetworkingTests.kt
@@ -17,7 +17,7 @@ class NetworkingTests {
     fun testNetworkingHttpRequest() = runTest {
         val networkDriver = NetworkDriver()
         val request = MockHttpRequest(
-            "https://android.com",
+            "https://api.mainnet-beta.solana.com/",
             "get",
             mapOf("html" to "Content-Type"),
             "echo"


### PR DESCRIPTION
…sponse

- Update the URL in the `MockHttpRequest` to `"https://api.mainnet-beta.solana.com/"`
- Assert that the `response` is not null in the test case.