### PR TITLE
chore: Refactor file naming for consistency.

### DIFF
--- a/solanapublickeys/src/iosMain/kotlin/foundation/metaplex/solanapublickeys/NSDataByteArray.kt
+++ b/solanapublickeys/src/iosMain/kotlin/foundation/metaplex/solanapublickeys/NSDataByteArray.kt
@@ -1,4 +1,4 @@
-package foundation.metaplex.solana
+package foundation.metaplex.solanapublickeys
 
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.memScoped


### PR DESCRIPTION
- Renamed `NSDataByteArray.kt` file in the `solanapublickeys` project
- Made various changes to files in the commit
- Reviewed files with omitted changes in the diff summary