### PR TITLE
Exclude integration tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,3 +13,14 @@ plugins {
 tasks.register("clean", Delete::class) {
     delete(rootProject.buildDir)
 }
+
+subprojects.forEach { project ->
+    project.afterEvaluate {
+        project.tasks.filterIsInstance<Test>().forEach { testTask ->
+            if (!project.hasProperty("includeIntegrationTests") ||
+                project.property("includeIntegrationTests") == false) {
+                testTask.exclude("**/*IntegTest*")
+            }
+        }
+    }
+}

--- a/mplbubblegum/src/commonTest/kotlin/foundation/metaplex/mplbubblegum/BubblegumTests.kt
+++ b/mplbubblegum/src/commonTest/kotlin/foundation/metaplex/mplbubblegum/BubblegumTests.kt
@@ -41,7 +41,7 @@ class HotSigner(private val keyPair: Keypair) : Signer {
 
 
 
-class BubblegumTest {
+class BubblegumIntegTest {
 
     companion object {
 

--- a/readapi/src/commonTest/kotlin/foundation/metaplex/readapi/ReadApiDecoratorTests.kt
+++ b/readapi/src/commonTest/kotlin/foundation/metaplex/readapi/ReadApiDecoratorTests.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
-class ReadApiDecoratorTests {
+class ReadApiDecoratorIntegTests {
     private val testingTimeout = 30.seconds
     private var rpcUrl: String = "https://api.mainnet-beta.solana.com"
 

--- a/rpc/src/commonTest/kotlin/foundation/metaplex/rpc/RpcTests.kt
+++ b/rpc/src/commonTest/kotlin/foundation/metaplex/rpc/RpcTests.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-class RpcTests {
+class RpcIntegTests {
     private var rpcUrl: String = "https://api.mainnet-beta.solana.com"
 
     @Test


### PR DESCRIPTION
Integration tests are now excluded by default. They can still be run by adding the following property:
`-PincludeIntegrationTests`  

This is a partial solution to remove the flaky and broken integration tests. Eventually we can add corresponding unit tests that cover these cases and better separate the integration tests. 