### PR TITLE
Read API Compression Empty String to Null Literal Workaround

### DIFF
--- a/readapi/src/commonTest/kotlin/foundation/metaplex/readapi/ReadApiDecoratorTests.kt
+++ b/readapi/src/commonTest/kotlin/foundation/metaplex/readapi/ReadApiDecoratorTests.kt
@@ -57,7 +57,7 @@ class ReadApiDecoratorIntegTests {
         )
         assertEquals(1000, assets.total)
         assertEquals(
-            PublicKey("GY4Ncxdtz55bMLfmXL38EJk92hxokCHWenjGsF6JDYMZ"),
+            PublicKey("JEAAuQNfGk1NsnCLAQo8GYDFJibJVn8NVxwbujzcUk1K"),
             assets.items.first().id
         )
     }

--- a/rpc/src/commonMain/kotlin/foundation/metaplex/rpc/serializers/PublicKeySerializers.kt
+++ b/rpc/src/commonMain/kotlin/foundation/metaplex/rpc/serializers/PublicKeySerializers.kt
@@ -11,6 +11,7 @@ import com.funkatronics.kborsh.BorshDecoder
 import com.funkatronics.kborsh.BorshEncoder
 import foundation.metaplex.solanapublickeys.PublicKey
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ByteArraySerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
@@ -78,5 +79,8 @@ object PublicKeyAsStringSerializer : KSerializer<PublicKey> {
      * @return The deserialized PublicKey object.
      * @throws SerializationException if the input string cannot be parsed as a PublicKey.
      */
-    override fun deserialize(decoder: Decoder): PublicKey = PublicKey(decoder.decodeString())
+    override fun deserialize(decoder: Decoder): PublicKey = decoder.decodeString().let {
+        if (it.isEmpty()) throw SerializationException("received empty public key")
+        PublicKey(it)
+    }
 }


### PR DESCRIPTION
Read API is returning malformed json with empty strings ("") instead of null literals for public keys. Kotlin serialization cannot handle this directly so a workaround was added to replace these empty strings with null literals. This fixes the `ReadApiDecorator` tests