### PR TITLE
Optimized dependencies definition

### DIFF
--- a/base58/build.gradle.kts
+++ b/base58/build.gradle.kts
@@ -37,12 +37,13 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(libs.crypto)
+                implementation(libs.crypto.hash)
             }
         }
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
+                implementation(libs.crypto.encoding)
             }
         }
         val jvmMain by getting

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 bignum = "0.3.8"
 crypto = "0.1.4"
+cryptoEncoding = "0.1.0"
 buffer = "1.3.1"
 ktor = "2.3.3"
 serialization = "1.6.0-RC"
@@ -19,7 +20,9 @@ kmpFrameworkBundler = "0.0.9"
 gradle = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 
 bignum = { group = "com.ionspin.kotlin", name = "bignum", version.ref = "bignum" }
-crypto = { group = "com.diglol.crypto", name = "crypto", version.ref = "crypto" }
+crypto-encoding = { group = "com.diglol.encoding", name = "encoding", version.ref = "cryptoEncoding" }
+crypto-hash = { group = "com.diglol.crypto", name = "hash", version.ref = "crypto" }
+crypto-pkc = { group = "com.diglol.crypto", name = "pkc", version.ref = "crypto" }
 buffer = { group = "com.ditchoom", name = "buffer", version.ref = "buffer" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }

--- a/rpc/build.gradle.kts
+++ b/rpc/build.gradle.kts
@@ -44,7 +44,7 @@ kotlin {
                 implementation(libs.kotlinx.serialization.json )
                 implementation(libs.kotlinx.coroutines.core)
                 implementation(libs.bignum)
-                implementation(libs.crypto)
+                implementation(libs.crypto.pkc)
                 implementation(libs.kborsh)
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.client.cio)

--- a/solanaeddsa/build.gradle.kts
+++ b/solanaeddsa/build.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
             dependencies {
                 implementation(project(mapOf("path" to ":signer")))
                 implementation(project(mapOf("path" to ":solanapublickeys")))
-                implementation(libs.crypto)
+                implementation(libs.crypto.pkc)
                 implementation(libs.web3core)
             }
         }

--- a/solanapublickeys/build.gradle.kts
+++ b/solanapublickeys/build.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
             dependencies {
                 implementation(project(mapOf("path" to ":base58")))
                 implementation(libs.buffer)
-                implementation(libs.crypto)
+                implementation(libs.crypto.hash)
                 api(libs.web3solana)
             }
         }


### PR DESCRIPTION
**What’s changed**
	•	Optimized diglol-crypto usage by switching from the full dependency to specific modules, avoiding inclusion of diglol.crypto:kdf (which depends on org.signal:argon2 with a non-16KB-aligned .so)
	
**Why**
	•	Minimizes dependency tree by avoiding unnecessary diglol-crypto modules
	•	Resolves a Google Play blocker: starting November 1, 2025, apps containing .so files not aligned to 16KB cannot be uploaded. [Details here](https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html)

**Result**
	•	Smaller dependency footprint
	•	Ensured compliance with upcoming Google Play requirements